### PR TITLE
Remove assignment alignment formatting rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ doSomething = ->
 
 ### Formatting
 
-- Use at least one space before an assignment operator.
-- Use **only** one space after an assignment operator.
-- Use reasonable aligning for expression symbols _(e.g `=`, `:`)_. Do not try to align everything, as it's making it hard to move the lines. Try to use plugins for this: Tabularize for Vim, Alignment for Sublime Text
+- Use **only one** space before and after an assignment operator.
+- Use **no** space before and **only one** space after object assignment operator.
 
 ```coffee
 # No
@@ -137,26 +136,19 @@ longVariable = 'string'
 # Yes
 x = 1
 y = 2
-
 longVariable = 'string'
 
 # No
-obj =
-  var: 1
-  short: 2
-  longVariable: 3
-
 obj            =
   var          : 1
   short        : 2
   longVariable : 3
 
-
 # Yes
 obj =
-  var          : 1
-  short        : 2
-  longVariable : 3
+  var: 1
+  short: 2
+  longVariable: 3
 ```
 
 #### Follow idiomatic CoffeeScript practises for expressions, assignments, booleans etc.


### PR DESCRIPTION
The main reason for this change is to reduce noise in the diffs. 

One line changes will be, one line changes if we change into this direction.

### Example

```coffee
someVar         = ''
otherVar        = ''
varWithLongName = ''
anotherVar      = ''
```

we want to remove `varWithLongName` and commit this:

```coffee
someVar    = ''
otherVar   = ''
anotherVar = ''
```

here is the diff output:

```diff
diff --git a/example.coffee b/example.coffee
index a0f9af2..8d965ee 100644
--- a/example.coffee
+++ b/example.coffee
@@ -1,4 +1,3 @@
-someVar         = ''
-otherVar        = ''
-varWithLongName = ''
-anotherVar      = ''
+someVar    = ''
+otherVar   = ''
+anotherVar = ''
```
----
Here is the same results without the assignment formatting rule:

```coffee
someVar = ''
otherVar = ''
varWithLongName = ''
anotherVar = ''
```

Remove `varWithLongName`:

```coffee
someVar = ''
otherVar = ''
anotherVar = ''
```

diff output:

```diff
diff --git a/example2.coffee b/example2.coffee
index ef3e594..d160013 100644
--- a/example2.coffee
+++ b/example2.coffee
@@ -1,5 +1,4 @@
 someVar = ''
 otherVar = ''
-varWithLongName = ''
 anotherVar = ''
```

/cc @koding/coffeedevs